### PR TITLE
Improve train set checking in sim command

### DIFF
--- a/src/sim.ts
+++ b/src/sim.ts
@@ -19,7 +19,7 @@ import {
   Lifestyle,
   permedSkills,
 } from "libram";
-import { nextConfigurable } from "libram/dist/resources/2022/TrainSet";
+import { have as haveTrainSet, nextConfigurable } from "libram/dist/resources/2022/TrainSet";
 
 class Hardcoded {
   have: boolean;
@@ -49,10 +49,7 @@ function buildIotmList(): Requirement[] {
       why: "Many test improvements",
     },
     {
-      thing: new Hardcoded(
-        have($item`model train set`) || getWorkshed() === $item`model train set`,
-        "Model train set"
-      ),
+      thing: new Hardcoded(haveTrainSet(), "Model train set"),
       why: "Leveling",
     },
     {
@@ -402,10 +399,7 @@ function buildMiscList(): Requirement[] {
       why: "Ensures Novelty Tropical Skeleton",
     },
     {
-      thing: new Hardcoded(
-        have($item`model train set`) && !nextConfigurable(),
-        "Configurable Trainset"
-      ),
+      thing: new Hardcoded(haveTrainSet() && !nextConfigurable(), "Configurable Trainset"),
       why: "XP and meat during Powerleveling",
     },
     {


### PR DESCRIPTION
The configurable train set check wasn't handling the case where the train set was installed in the workshed. Rather than duplicate the "have item or in workshed" logic in a 2nd place I just used the function that's already available in the libram resource for train set.