### PR TITLE
Prevent trying to harvest empty garden

### DIFF
--- a/src/tasks/runstart.ts
+++ b/src/tasks/runstart.ts
@@ -364,8 +364,7 @@ export const RunStartQuest: Quest = {
     {
       name: "Harvest Garden",
       completed: () =>
-        !getGarden() ||
-        getGarden() === $item`packet of mushroom spores` ||
+        [$item`none`, $item`packet of mushroom spores`].includes(getGarden()) ||
         getCampground()[getGarden().name] === 0 ||
         get("instant_saveGarden", false),
       do: () => cliExecute("garden pick"),

--- a/src/tasks/runstart.ts
+++ b/src/tasks/runstart.ts
@@ -364,7 +364,7 @@ export const RunStartQuest: Quest = {
     {
       name: "Harvest Garden",
       completed: () =>
-        [$item`none`, $item`packet of mushroom spores`].includes(getGarden()) ||
+        [$item.none, $item`packet of mushroom spores`].includes(getGarden()) ||
         getCampground()[getGarden().name] === 0 ||
         get("instant_saveGarden", false),
       do: () => cliExecute("garden pick"),


### PR DESCRIPTION
The previous check was looking for getGarden() to be falsy when the garden is empty, but it returns $item\`none\` instead. Let's explicitly check that instead of checking truthiness.

(Note: I have a garden installed so I wasn't able to fully test that this check fixes the issue, but it seems logically correct.)