### PR TITLE
guard against wasting turns with comma and emit a warning

### DIFF
--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -110,14 +110,20 @@ export const FamiliarWeightQuest: Quest = {
             ),
             $item`love song of icy revenge`
           );
+
         const heaviestWeight = familiarWeight(chooseHeaviestFamiliar()) + (have($item`astral pet sweater`) ? 10 : 0);
         const commaWeight = 6 + 11 * get("homemadeRobotUpgrades");
         const useComma = ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
             commaWeight > heaviestWeight);
+        if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
+            commaWeight < 105) {
+          print(`Comma Chameleon is not at max weight, use ${9 - get("homemadeRobotUpgrades")} more parts on Homemade Robot.`, "red");
+        }
         const useTrainbot = have($familiar`Mini-Trainbot`) &&
             ((familiarWeight($familiar`Mini-Trainbot`) + 25) > heaviestWeight);
         const useParrot = have($familiar`Exotic Parrot`) &&
             ((familiarWeight($familiar`Exotic Parrot`) + 15) > heaviestWeight);
+
         if (
           have($skill`Summon Clip Art`) &&
           !get("instant_saveClipArt", false) &&
@@ -152,10 +158,6 @@ export const FamiliarWeightQuest: Quest = {
           ) {
             tryAcquiringEffect($effect`Offhand Remarkable`);
           }
-        }
-        if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
-            commaWeight < 105) {
-          print(`Comma Chameleon is not at max weight, use ${9 - get("homemadeRobotUpgrades")} more parts on Homemade Robot.`, "red");
         }
       },
       do: (): void => {

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -116,11 +116,12 @@ export const FamiliarWeightQuest: Quest = {
           have($skill`Summon Clip Art`) &&
           !get("instant_saveClipArt", false) &&
           ($familiars`Mini-Trainbot, Exotic Parrot`.some((fam) => have(fam)) ||
-            $familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
-              heaviestWeight < commaWeight)
+          ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
+              heaviestWeight < commaWeight))
         ) {
           if (!have($item`box of Familiar Jacks`)) create($item`box of Familiar Jacks`, 1);
-          if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam))) {
+          if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
+              heaviestWeight < commaWeight) {
             useFamiliar($familiar`Homemade Robot`);
             use($item`box of Familiar Jacks`, 1);
             useFamiliar($familiar`Comma Chameleon`);

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -115,7 +115,8 @@ export const FamiliarWeightQuest: Quest = {
         if (
           have($skill`Summon Clip Art`) &&
           !get("instant_saveClipArt", false) &&
-          ($familiars`Mini-Trainbot, Exotic Parrot`.some((fam) => have(fam)) ||
+          ((have($familiar`Mini-Trainbot`) && ((familiarWeight($familiar`Mini-Trainbot`) + 25) > heaviestWeight)) ||
+          (have($familiar`Exotic Parrot`) && ((familiarWeight($familiar`Exotic Parrot`) + 15) > heaviestWeight)) ||
           ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
               heaviestWeight < commaWeight))
         ) {

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -112,12 +112,14 @@ export const FamiliarWeightQuest: Quest = {
           );
 
         const heaviestWeight = familiarWeight(chooseHeaviestFamiliar()) + (have($item`astral pet sweater`) ? 10 : 0);
-        const commaWeight = 6 + 11 * get("homemadeRobotUpgrades");
+        const calcCommaWeight = (upgrades: number) => 6 + 11 * upgrades;
+        const maxRobotUpgrades = 9;
+        const commaWeight = calcCommaWeight(get("homemadeRobotUpgrades"));
         const useComma = ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
             commaWeight > heaviestWeight);
         if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
-            commaWeight < 105) {
-          print(`Comma Chameleon is not at max weight, use ${9 - get("homemadeRobotUpgrades")} more parts on Homemade Robot.`, "red");
+            commaWeight < calcCommaWeight(maxRobotUpgrades)) {
+          print(`Comma Chameleon is not at max weight, use ${maxRobotUpgrades - get("homemadeRobotUpgrades")} more parts on Homemade Robot.`, "red");
         }
         const useTrainbot = have($familiar`Mini-Trainbot`) &&
             ((familiarWeight($familiar`Mini-Trainbot`) + 25) > heaviestWeight);

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -149,9 +149,10 @@ export const FamiliarWeightQuest: Quest = {
           ) {
             tryAcquiringEffect($effect`Offhand Remarkable`);
           }
-        } else if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
-            heaviestWeight > commaWeight) {
-          print(`Comma Chameleon weighs ${heaviestWeight - commaWeight} lbs less than heaviest normal familiar, use more parts on Homemade Robot.`, "red");
+        }
+        if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
+            commaWeight < 111) {
+          print(`Comma Chameleon is not at max weight, use ${10 - get("homemadeRobotUpgrades")} more parts on Homemade Robot.`, "red");
         }
       },
       do: (): void => {

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -154,8 +154,8 @@ export const FamiliarWeightQuest: Quest = {
           }
         }
         if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
-            commaWeight < 111) {
-          print(`Comma Chameleon is not at max weight, use ${10 - get("homemadeRobotUpgrades")} more parts on Homemade Robot.`, "red");
+            commaWeight < 105) {
+          print(`Comma Chameleon is not at max weight, use ${9 - get("homemadeRobotUpgrades")} more parts on Homemade Robot.`, "red");
         }
       },
       do: (): void => {

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -116,6 +116,8 @@ export const FamiliarWeightQuest: Quest = {
             $familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)))
         ) {
           if (!have($item`box of Familiar Jacks`)) create($item`box of Familiar Jacks`, 1);
+          useFamiliar(chooseHeaviestFamiliar());
+          const heaviestTurns = CommunityService.FamiliarWeight.actualCost();
           if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam))) {
             useFamiliar($familiar`Homemade Robot`);
             use($item`box of Familiar Jacks`, 1);
@@ -126,6 +128,11 @@ export const FamiliarWeightQuest: Quest = {
               )}&pwd`
             );
             visitUrl("charpane.php");
+            const commaTurns = CommunityService.FamiliarWeight.actualCost();
+            if (commaTurns > heaviestTurns) {
+              print(`Using Comma Chameleon expected to take ${commaTurns}, which is more than ${heaviestTurns} using a normal familiar, use more parts on Homemade Robot.`, "red");
+              useFamiliar(chooseHeaviestFamiliar());
+            }
           } else {
             if (have($familiar`Mini-Trainbot`)) useFamiliar($familiar`Mini-Trainbot`);
             else useFamiliar($familiar`Exotic Parrot`);

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -112,17 +112,19 @@ export const FamiliarWeightQuest: Quest = {
           );
         const heaviestWeight = familiarWeight(chooseHeaviestFamiliar()) + (have($item`astral pet sweater`) ? 10 : 0);
         const commaWeight = 6 + 11 * get("homemadeRobotUpgrades");
+        const useComma = ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
+            commaWeight > heaviestWeight);
+        const useTrainbot = have($familiar`Mini-Trainbot`) &&
+            ((familiarWeight($familiar`Mini-Trainbot`) + 25) > heaviestWeight);
+        const useParrot = have($familiar`Exotic Parrot`) &&
+            ((familiarWeight($familiar`Exotic Parrot`) + 15) > heaviestWeight);
         if (
           have($skill`Summon Clip Art`) &&
           !get("instant_saveClipArt", false) &&
-          ((have($familiar`Mini-Trainbot`) && ((familiarWeight($familiar`Mini-Trainbot`) + 25) > heaviestWeight)) ||
-          (have($familiar`Exotic Parrot`) && ((familiarWeight($familiar`Exotic Parrot`) + 15) > heaviestWeight)) ||
-          ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
-              heaviestWeight < commaWeight))
+          (useTrainbot||useParrot||useComma)
         ) {
           if (!have($item`box of Familiar Jacks`)) create($item`box of Familiar Jacks`, 1);
-          if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
-              heaviestWeight < commaWeight) {
+          if (useComma) {
             useFamiliar($familiar`Homemade Robot`);
             use($item`box of Familiar Jacks`, 1);
             useFamiliar($familiar`Comma Chameleon`);
@@ -133,7 +135,7 @@ export const FamiliarWeightQuest: Quest = {
             );
             visitUrl("charpane.php");
           } else {
-            if (have($familiar`Mini-Trainbot`)) useFamiliar($familiar`Mini-Trainbot`);
+            if (useTrainbot) useFamiliar($familiar`Mini-Trainbot`);
             else useFamiliar($familiar`Exotic Parrot`);
             use($item`box of Familiar Jacks`, 1);
           }

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -4,6 +4,7 @@ import {
   create,
   Effect,
   equippedItem,
+  familiarWeight,
   haveEffect,
   itemAmount,
   mySign,
@@ -109,15 +110,16 @@ export const FamiliarWeightQuest: Quest = {
             ),
             $item`love song of icy revenge`
           );
+        const heaviestWeight = familiarWeight(chooseHeaviestFamiliar());
+        const commaWeight = 1 + 11 * get("homemadeRobotUpgrades");
         if (
           have($skill`Summon Clip Art`) &&
           !get("instant_saveClipArt", false) &&
           ($familiars`Mini-Trainbot, Exotic Parrot`.some((fam) => have(fam)) ||
-            $familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)))
+            $familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
+              heaviestWeight < commaWeight)
         ) {
           if (!have($item`box of Familiar Jacks`)) create($item`box of Familiar Jacks`, 1);
-          useFamiliar(chooseHeaviestFamiliar());
-          const heaviestTurns = CommunityService.FamiliarWeight.actualCost();
           if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam))) {
             useFamiliar($familiar`Homemade Robot`);
             use($item`box of Familiar Jacks`, 1);
@@ -128,11 +130,6 @@ export const FamiliarWeightQuest: Quest = {
               )}&pwd`
             );
             visitUrl("charpane.php");
-            const commaTurns = CommunityService.FamiliarWeight.actualCost();
-            if (commaTurns > heaviestTurns) {
-              print(`Using Comma Chameleon expected to take ${commaTurns}, which is more than ${heaviestTurns} using a normal familiar, use more parts on Homemade Robot.`, "red");
-              useFamiliar(chooseHeaviestFamiliar());
-            }
           } else {
             if (have($familiar`Mini-Trainbot`)) useFamiliar($familiar`Mini-Trainbot`);
             else useFamiliar($familiar`Exotic Parrot`);
@@ -151,6 +148,9 @@ export const FamiliarWeightQuest: Quest = {
           ) {
             tryAcquiringEffect($effect`Offhand Remarkable`);
           }
+        } else if ($familiars`Comma Chameleon, Homemade Robot`.every((fam) => have(fam)) &&
+            heaviestWeight > commaWeight) {
+          print(`Comma Chameleon weighs ${heaviestWeight - commaWeight} lbs less than heaviest normal familiar, use more parts on Homemade Robot.`, "red");
         }
       },
       do: (): void => {

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -110,8 +110,8 @@ export const FamiliarWeightQuest: Quest = {
             ),
             $item`love song of icy revenge`
           );
-        const heaviestWeight = familiarWeight(chooseHeaviestFamiliar());
-        const commaWeight = 1 + 11 * get("homemadeRobotUpgrades");
+        const heaviestWeight = familiarWeight(chooseHeaviestFamiliar()) + (have($item`astral pet sweater`) ? 10 : 0);
+        const commaWeight = 6 + 11 * get("homemadeRobotUpgrades");
         if (
           have($skill`Summon Clip Art`) &&
           !get("instant_saveClipArt", false) &&


### PR DESCRIPTION
Do a quick check to ensure comma is worth using, and emit a warning if its not ready before switching back to the heaviest familiar.