### PR TITLE
Add offhand remarkable to offhand check

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -578,7 +578,11 @@ export function computeCombatFrequency(): number {
   const shoeGum = get("hasDetectiveSchool") && !get("instant_saveCopDollars", false) ? -5 : 0;
   const silentRunning = -5;
   const feelingLonely = have($skill`Feel Lonely`) ? -5 : 0;
-  const offhandRemarkable = have($skill`Aug. 13th: Left/Off Hander's Day!`) && !forbiddenEffects.includes($effect`Offhand Remarkable`) ? offhand : 0;
+  const offhandRemarkable =
+    have($skill`Aug. 13th: Left/Off Hander's Day!`) &&
+    !forbiddenEffects.includes($effect`Offhand Remarkable`)
+      ? offhand
+      : 0;
   const effects = sumNumbers([
     rose,
     smoothMovements,
@@ -589,7 +593,7 @@ export function computeCombatFrequency(): number {
     shoeGum,
     silentRunning,
     feelingLonely,
-    offhandRemarkable
+    offhandRemarkable,
   ]);
 
   const disgeist = have($familiar`Disgeist`) ? -5 : 0;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -578,6 +578,7 @@ export function computeCombatFrequency(): number {
   const shoeGum = get("hasDetectiveSchool") && !get("instant_saveCopDollars", false) ? -5 : 0;
   const silentRunning = -5;
   const feelingLonely = have($skill`Feel Lonely`) ? -5 : 0;
+  const offhandRemarkable = have($skill`Aug. 13th: Left/Off Hander's Day!`) && !forbiddenEffects.includes($effect`Offhand Remarkable`) ? offhand : 0;
   const effects = sumNumbers([
     rose,
     smoothMovements,
@@ -588,6 +589,7 @@ export function computeCombatFrequency(): number {
     shoeGum,
     silentRunning,
     feelingLonely,
+    offhandRemarkable
   ]);
 
   const disgeist = have($familiar`Disgeist`) ? -5 : 0;

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -386,13 +386,13 @@ export const LevelingQuest: Quest = {
         get("_roninStoragePulls")
           .split(",")
           .includes(toInt($item`Deep Dish of Legend`).toString()) ||
-        get("instant_skipDeepDishOfLegend", false),
+        get("_instant_skipDeepDishOfLegend", false),
       do: (): void => {
         if (storageAmount($item`Deep Dish of Legend`) === 0) {
           print("Uh oh! You do not seem to have a Deep Dish of Legend in Hagnk's", "red");
           print("Consider pulling something to make up for the turngen and 300%mus,", "red");
           print(
-            "then type 'set instant_skipDeepDishOfLegend=true' before re-running instantsccs",
+            "then type 'set _instant_skipDeepDishOfLegend=true' before re-running instantsccs",
             "red"
           );
         }
@@ -408,7 +408,7 @@ export const LevelingQuest: Quest = {
         get("_roninStoragePulls")
           .split(",")
           .includes(toInt($item`Calzone of Legend`).toString()) ||
-        get("instant_skipCalzoneOfLegend", false),
+        get("_instant_skipCalzoneOfLegend", false),
       do: (): void => {
         if (storageAmount($item`Calzone of Legend`) === 0) {
           print("Uh oh! You do not seem to have a Calzone of Legend in Hagnk's", "red");
@@ -417,7 +417,7 @@ export const LevelingQuest: Quest = {
             "red"
           );
           print(
-            "then type 'set instant_skipCalzoneOfLegend=true' before re-running instantsccs",
+            "then type 'set _instant_skipCalzoneOfLegend=true' before re-running instantsccs",
             "red"
           );
         }
@@ -433,13 +433,13 @@ export const LevelingQuest: Quest = {
         get("_roninStoragePulls")
           .split(",")
           .includes(toInt($item`Pizza of Legend`).toString()) ||
-        get("instant_skipPizzaOfLegend", false),
+        get("_instant_skipPizzaOfLegend", false),
       do: (): void => {
         if (storageAmount($item`Pizza of Legend`) === 0) {
           print("Uh oh! You do not seem to have a Pizza of Legend in Hagnk's", "red");
           print("Consider pulling something to make up for the turngen and 300%mox,", "red");
           print(
-            "then type 'set instant_skipPizzaOfLegend=true' before re-running instantsccs",
+            "then type 'set _instant_skipPizzaOfLegend=true' before re-running instantsccs",
             "red"
           );
         }

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -386,13 +386,13 @@ export const LevelingQuest: Quest = {
         get("_roninStoragePulls")
           .split(",")
           .includes(toInt($item`Deep Dish of Legend`).toString()) ||
-        get("_instant_skipDeepDishOfLegend", false),
+        get("instant_skipDeepDishOfLegend", false),
       do: (): void => {
         if (storageAmount($item`Deep Dish of Legend`) === 0) {
           print("Uh oh! You do not seem to have a Deep Dish of Legend in Hagnk's", "red");
           print("Consider pulling something to make up for the turngen and 300%mus,", "red");
           print(
-            "then type 'set _instant_skipDeepDishOfLegend=true' before re-running instantsccs",
+            "then type 'set instant_skipDeepDishOfLegend=true' before re-running instantsccs",
             "red"
           );
         }
@@ -408,7 +408,7 @@ export const LevelingQuest: Quest = {
         get("_roninStoragePulls")
           .split(",")
           .includes(toInt($item`Calzone of Legend`).toString()) ||
-        get("_instant_skipCalzoneOfLegend", false),
+        get("instant_skipCalzoneOfLegend", false),
       do: (): void => {
         if (storageAmount($item`Calzone of Legend`) === 0) {
           print("Uh oh! You do not seem to have a Calzone of Legend in Hagnk's", "red");
@@ -417,7 +417,7 @@ export const LevelingQuest: Quest = {
             "red"
           );
           print(
-            "then type 'set _instant_skipCalzoneOfLegend=true' before re-running instantsccs",
+            "then type 'set instant_skipCalzoneOfLegend=true' before re-running instantsccs",
             "red"
           );
         }
@@ -433,13 +433,13 @@ export const LevelingQuest: Quest = {
         get("_roninStoragePulls")
           .split(",")
           .includes(toInt($item`Pizza of Legend`).toString()) ||
-        get("_instant_skipPizzaOfLegend", false),
+        get("instant_skipPizzaOfLegend", false),
       do: (): void => {
         if (storageAmount($item`Pizza of Legend`) === 0) {
           print("Uh oh! You do not seem to have a Pizza of Legend in Hagnk's", "red");
           print("Consider pulling something to make up for the turngen and 300%mox,", "red");
           print(
-            "then type 'set _instant_skipPizzaOfLegend=true' before re-running instantsccs",
+            "then type 'set instant_skipPizzaOfLegend=true' before re-running instantsccs",
             "red"
           );
         }


### PR DESCRIPTION
Currently, the bonus provided by using Offhand Remarkable with the unbreakable umbrella isn't accounted for when determining if NC should be done before FamWeight, this PR adds a check for it and includes it in the "effects" value of the check. 