### PR TITLE
Ensure we don't barrel pray non-Sauce; LOV improve

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -67,12 +67,12 @@ import { forbiddenEffects } from "./resources";
 
 export const startingClan = getClanName();
 export const motherSlimeClan = Clan.getWhitelisted().find(
-  (c) => c.name.toLowerCase() === get("instant_motherSlimeClan", "").toLowerCase(),
+  (c) => c.name.toLowerCase() === get("instant_motherSlimeClan", "").toLowerCase()
 )
   ? get("instant_motherSlimeClan", "")
   : Clan.getWhitelisted().find((c) => c.name.toLowerCase() === "csloopers unite")
-    ? "CSLoopers Unite"
-    : "";
+  ? "CSLoopers Unite"
+  : "";
 
 export const testModifiers = new Map([
   [CommunityService.HP, ["Maximum HP", "Maximum HP Percent", "Muscle", "Muscle Percent"]],
@@ -90,7 +90,7 @@ export const testModifiers = new Map([
 
 export function checkGithubVersion(): void {
   const gitBranches: { name: string; commit: { sha: string } }[] = JSON.parse(
-    visitUrl(`https://api.github.com/repos/Pantocyclus/InstantSCCS/branches`),
+    visitUrl(`https://api.github.com/repos/Pantocyclus/InstantSCCS/branches`)
   );
   const releaseBranch = gitBranches.find((branchInfo) => branchInfo.name === "release");
   const releaseSHA = releaseBranch?.commit.sha ?? "Not Found";
@@ -101,7 +101,7 @@ export function checkGithubVersion(): void {
   } else {
     print(
       `InstantSCCS is out of date - your version was last updated on ${localBranch.last_changed_date}.`,
-      "red",
+      "red"
     );
     print("Please run 'git update'!", "red");
     print(`Local Version: ${localSHA}.`);
@@ -142,13 +142,13 @@ export function convertMilliseconds(milliseconds: number): string {
 function logRelevantStats(whichTest: CommunityService): void {
   if (
     [CommunityService.Muscle, CommunityService.Mysticality, CommunityService.Moxie].includes(
-      whichTest,
+      whichTest
     )
   ) {
     const testStat = toStat(whichTest.statName);
     const statString = testStat.toString().slice(0, 3);
     print(
-      `Base ${statString}: ${myBasestat(testStat)}; Buffed ${statString}: ${myBuffedstat(testStat)}`,
+      `Base ${statString}: ${myBasestat(testStat)}; Buffed ${statString}: ${myBuffedstat(testStat)}`
     );
   } else if (whichTest === CommunityService.HP) {
     print(`Buffed Mus: ${myBuffedstat($stat`Muscle`)}; HP: ${myMaxhp()};`);
@@ -165,7 +165,7 @@ export function logTestSetup(whichTest: CommunityService): void {
     } takes ${testTurns} adventure${testTurns === 1 ? "" : "s"} (predicted: ${
       whichTest.prediction
     }).`,
-    "blue",
+    "blue"
   );
   set(`_CSTest${whichTest.id}`, testTurns + (have($effect`Simmering`) ? 1 : 0));
 }
@@ -229,7 +229,9 @@ export function canAcquireEffect(ef: Effect): boolean {
         case "synthesize":
           return false; // We currently don't support sweet synthesis
         case "barrelprayer":
-          return get("barrelShrineUnlocked") && !get("_barrelPrayer");
+          return (
+            get("barrelShrineUnlocked") && !get("_barrelPrayer") && myClass() === $class`Sauceror`
+          );
         case "witchess":
           return Witchess.have() && get("puzzleChampBonus") >= 20 && !get("_witchessBuff");
         case "telescope":
@@ -370,8 +372,8 @@ export const synthExpBuff =
   mainStat === $stat`Muscle`
     ? $effect`Synthesis: Movement`
     : mainStat === $stat`Mysticality`
-      ? $effect`Synthesis: Learning`
-      : $effect`Synthesis: Style`;
+    ? $effect`Synthesis: Learning`
+    : $effect`Synthesis: Style`;
 
 export const complexCandies = $items``.filter((candy) => candy.candyType === "complex");
 const peppermintCandiesCosts = new Map<Item, number>([
@@ -384,7 +386,7 @@ const peppermintCandiesCosts = new Map<Item, number>([
   [$item`cane-mail shirt`, 15],
 ]);
 const nonPeppermintCandies = complexCandies.filter(
-  (candy) => !Array.from(peppermintCandiesCosts.keys()).includes(candy),
+  (candy) => !Array.from(peppermintCandiesCosts.keys()).includes(candy)
 );
 
 function haveCandies(a: Item, b: Item): boolean {
@@ -395,7 +397,7 @@ function haveCandies(a: Item, b: Item): boolean {
     else
       candiesRequired.set(
         $item`peppermint sprout`,
-        currentAmount + (peppermintCandiesCosts.get(candy) ?? Infinity),
+        currentAmount + (peppermintCandiesCosts.get(candy) ?? Infinity)
       );
   });
 
@@ -424,7 +426,7 @@ export function getSynthExpBuff(): void {
     left.map((it) => retrievePrice(it)).reduce((acc, val) => acc + val) <
     right.map((it) => retrievePrice(it)).reduce((acc, val) => acc + val)
       ? left
-      : right,
+      : right
   );
   if (bestPair[0] === bestPair[1]) retrieveItem(bestPair[0], 2);
   else bestPair.forEach((it) => retrieveItem(it));
@@ -477,8 +479,8 @@ export function camelFightsLeft(): number {
     ? have($effect`Shadow Affinity`)
       ? haveEffect($effect`Shadow Affinity`)
       : get("_shadowAffinityToday")
-        ? 11
-        : 0
+      ? 11
+      : 0
     : 0;
   const snojo = get("snojoAvailable") ? 10 - get("_snojoFreeFights") : 0;
   const NEP = get("neverendingPartyAlways") ? 10 - get("_neverendingPartyFreeTurns") : 0;
@@ -569,7 +571,7 @@ export function computeCombatFrequency(): number {
             .split(", ")
             .filter((s) => s.includes("Combat Frequency"))
             .join("")
-            .split(": ")[1],
+            .split(": ")[1]
         )
       : 0;
   const shadowWaters = have($item`closed-circuit pay phone`) ? -10 : 0;
@@ -621,7 +623,7 @@ export function computeCombatFrequency(): number {
 
   print("Determining if we should run NC before fam test...");
   print(
-    `Hat ${hat}, Shirt ${shirt}, Back ${back}, Offhand ${offhand}, Pants ${pants}, Accessories ${accessories}, Effects ${effects}, Familiar ${familiar}, Others ${others}`,
+    `Hat ${hat}, Shirt ${shirt}, Back ${back}, Offhand ${offhand}, Pants ${pants}, Accessories ${accessories}, Effects ${effects}, Familiar ${familiar}, Others ${others}`
   );
   if (total <= -95) {
     print(`Total ${total} <= -95`, "green");

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -123,6 +123,12 @@ const freeFightMonsters: Monster[] = $monsters`Witchess Bishop, Witchess King, W
 const craftedCBBFoods: Item[] = $items`honey bun of Boris, roasted vegetable of Jarlsberg, Pete's rich ricotta, plain calzone`;
 const craftedCBBEffects: Effect[] = craftedCBBFoods.map((it) => effectModifier(it, "effect"));
 let triedCraftingCBBFoods = false;
+const LOVEquip =
+  mainStatStr === $stat`Muscle`
+    ? "LOV Eardigan"
+    : mainStatStr === $stat`Mysticality`
+    ? "LOV Epaulettes"
+    : "LOV Earring";
 
 const muscleList: Effect[] = [
   $effect`Seal Clubbing Frenzy`,
@@ -163,8 +169,8 @@ const statEffects =
   mainStatStr === `Muscle`
     ? muscleList
     : mainStatStr === `Mysticality`
-      ? mysticalityList
-      : moxieList;
+    ? mysticalityList
+    : moxieList;
 
 const usefulEffects: Effect[] = [
   // Stats
@@ -242,7 +248,7 @@ export function bestShadowRift(): Location {
                 m === $monster`shadow guy` && have($skill`Just the Facts`)
                   ? $item`pocket wish`
                   : $item.none,
-              ].filter((i) => i !== $item.none),
+              ].filter((i) => i !== $item.none)
             )
             .reduce((acc, val) => acc.concat(val), []);
           return sum(drops, mallPrice);
@@ -396,7 +402,7 @@ export const LevelingQuest: Quest = {
           print("Consider pulling something to make up for the turngen and 300%mus,", "red");
           print(
             "then type 'set _instant_skipDeepDishOfLegend=true' before re-running instantsccs",
-            "red",
+            "red"
           );
         }
         takeStorage($item`Deep Dish of Legend`, 1);
@@ -417,11 +423,11 @@ export const LevelingQuest: Quest = {
           print("Uh oh! You do not seem to have a Calzone of Legend in Hagnk's", "red");
           print(
             "Consider pulling something to make up for the turngen and 300%myst (e.g. a roasted vegetable focaccia),",
-            "red",
+            "red"
           );
           print(
             "then type 'set _instant_skipCalzoneOfLegend=true' before re-running instantsccs",
-            "red",
+            "red"
           );
         }
         takeStorage($item`Calzone of Legend`, 1);
@@ -443,7 +449,7 @@ export const LevelingQuest: Quest = {
           print("Consider pulling something to make up for the turngen and 300%mox,", "red");
           print(
             "then type 'set _instant_skipPizzaOfLegend=true' before re-running instantsccs",
-            "red",
+            "red"
           );
         }
         takeStorage($item`Pizza of Legend`, 1);
@@ -460,11 +466,11 @@ export const LevelingQuest: Quest = {
         if (storageAmount($item`one-day ticket to Dinseylandfill`) === 0) {
           print(
             "Uh oh! You do not seem to have a one-day ticket to Dinseylandfill in Hagnk's",
-            "red",
+            "red"
           );
           print(
             "Try to purchase one from the mall with your meat from Hagnk's before re-running instantsccs",
-            "red",
+            "red"
           );
         }
         takeStorage($item`one-day ticket to Dinseylandfill`, 1);
@@ -770,8 +776,8 @@ export const LevelingQuest: Quest = {
             .trySkill($skill`Chest X-Ray`)
             .trySkill($skill`Gingerbread Mob Hit`)
             .trySkill($skill`Shattering Punch`)
-            .default(),
-        ).abort(),
+            .default()
+        ).abort()
       ),
       outfit: () => ({
         ...baseOutfit(),
@@ -801,7 +807,7 @@ export const LevelingQuest: Quest = {
         Macro.trySkill($skill`Curse of Weaksauce`)
           .tryItem($item`blue rocket`)
           .tryItem($item`red rocket`)
-          .default(),
+          .default()
       ),
       outfit: () => ({
         ...baseOutfit(false),
@@ -866,7 +872,7 @@ export const LevelingQuest: Quest = {
       combat: new CombatStrategy().macro(
         Macro.tryItem($item`red rocket`)
           .trySkill($skill`Recall Facts: %phylum Circadian Rhythms`)
-          .default(),
+          .default()
       ),
       outfit: () => ({
         ...baseOutfit(),
@@ -927,7 +933,7 @@ export const LevelingQuest: Quest = {
       completed: () => get("_snojoFreeFights") >= 10 || !get("snojoAvailable"),
       do: $location`The X-32-F Combat Training Snowman`,
       combat: new CombatStrategy().macro(
-        Macro.trySkill($skill`Recall Facts: %phylum Circadian Rhythms`).default(),
+        Macro.trySkill($skill`Recall Facts: %phylum Circadian Rhythms`).default()
       ),
       outfit: () => ({
         ...baseOutfit(),
@@ -1023,7 +1029,7 @@ export const LevelingQuest: Quest = {
       combat: new CombatStrategy().macro(
         Macro.if_("!haseffect Everything Looks Yellow", Macro.tryItem($item`yellow rocket`))
           .trySkill($skill`Feel Envy`)
-          .default(),
+          .default()
       ),
       outfit: () => ({
         ...baseOutfit(false),
@@ -1047,26 +1053,22 @@ export const LevelingQuest: Quest = {
       },
       completed: () => get("_loveTunnelUsed") || !get("loveTunnelAvailable"),
       do: () =>
-        TunnelOfLove.fightAll(
-          "LOV Epaulettes",
-          "Open Heart Surgery",
-          "LOV Extraterrestrial Chocolate",
-        ),
+        TunnelOfLove.fightAll(LOVEquip, "Open Heart Surgery", "LOV Extraterrestrial Chocolate"),
       combat: new CombatStrategy().macro(
         Macro.if_($monster`LOV Enforcer`, Macro.attack().repeat())
           .if_(
             $monster`LOV Engineer`,
             Macro.while_(
               `!mpbelow ${mpCost($skill`Toynado`)} && hasskill ${toInt($skill`Toynado`)}`,
-              Macro.skill($skill`Toynado`),
+              Macro.skill($skill`Toynado`)
             )
               .while_(
                 `!mpbelow ${mpCost($skill`Saucestorm`)} && hasskill ${toInt($skill`Saucestorm`)}`,
-                Macro.skill($skill`Saucestorm`),
+                Macro.skill($skill`Saucestorm`)
               )
-              .default(),
+              .default()
           )
-          .if_($monster`LOV Equivocator`, Macro.default()),
+          .if_($monster`LOV Equivocator`, Macro.default())
       ),
       outfit: () => ({
         ...baseOutfit(false),
@@ -1125,9 +1127,9 @@ export const LevelingQuest: Quest = {
               have($skill`Recall Facts: Monster Habitats`) &&
               (haveFreeBanish() ||
                 Array.from(getBanishedMonsters().values()).includes($monster`fluffy bunny`)),
-            Macro.trySkill($skill`Recall Facts: Monster Habitats`),
+            Macro.trySkill($skill`Recall Facts: Monster Habitats`)
           )
-          .default(useCinch),
+          .default(useCinch)
       ),
       outfit: () => ({
         ...baseOutfit,
@@ -1162,7 +1164,7 @@ export const LevelingQuest: Quest = {
         myBasestat(mainStat) >= 190, // no longer need to back up Witchess Kings
       do: $location`The Dire Warren`,
       combat: new CombatStrategy().macro(
-        Macro.trySkill($skill`Back-Up to your Last Enemy`).default(useCinch),
+        Macro.trySkill($skill`Back-Up to your Last Enemy`).default(useCinch)
       ),
       outfit: () => ({
         ...baseOutfit(),
@@ -1199,8 +1201,8 @@ export const LevelingQuest: Quest = {
             have($skill`Recall Facts: Monster Habitats`) &&
             (haveFreeBanish() ||
               Array.from(getBanishedMonsters().values()).includes($monster`fluffy bunny`)),
-          Macro.trySkill($skill`Recall Facts: Monster Habitats`),
-        ).default(useCinch),
+          Macro.trySkill($skill`Recall Facts: Monster Habitats`)
+        ).default(useCinch)
       ),
       post: (): void => {
         sendAutumnaton();
@@ -1224,7 +1226,7 @@ export const LevelingQuest: Quest = {
       combat: new CombatStrategy().macro(
         Macro.trySkill($skill`Feel Envy`)
           .trySkill($skill`Portscan`)
-          .default(),
+          .default()
       ),
       outfit: baseOutfit,
       limit: { tries: 1 },
@@ -1334,8 +1336,8 @@ export const LevelingQuest: Quest = {
             have($skill`Recall Facts: Monster Habitats`) &&
             (haveFreeBanish() ||
               Array.from(getBanishedMonsters().values()).includes($monster`fluffy bunny`)),
-          Macro.trySkill($skill`Recall Facts: Monster Habitats`),
-        ).default(useCinch),
+          Macro.trySkill($skill`Recall Facts: Monster Habitats`)
+        ).default(useCinch)
       ),
       outfit: baseOutfit,
       post: (): void => {
@@ -1398,7 +1400,7 @@ export const LevelingQuest: Quest = {
         Macro.tryItem($item`red rocket`)
           .trySkill($skill`Bowl Sideways`)
           .trySkill($skill`Recall Facts: %phylum Circadian Rhythms`)
-          .default(useCinch),
+          .default(useCinch)
       ),
       post: (): void => {
         haveCBBIngredients(false, true);
@@ -1520,7 +1522,7 @@ export const LevelingQuest: Quest = {
       combat: new CombatStrategy().macro(
         Macro.trySkill($skill`Curse of Weaksauce`)
           .attack()
-          .repeat(),
+          .repeat()
       ),
       outfit: {
         ...baseOutfit(),
@@ -1593,8 +1595,8 @@ export const LevelingQuest: Quest = {
             have($skill`Recall Facts: Monster Habitats`) &&
             (haveFreeBanish() ||
               Array.from(getBanishedMonsters().values()).includes($monster`fluffy bunny`)),
-          Macro.trySkill($skill`Recall Facts: Monster Habitats`),
-        ).default(useCinch),
+          Macro.trySkill($skill`Recall Facts: Monster Habitats`)
+        ).default(useCinch)
       ),
       outfit: baseOutfit,
       post: (): void => {
@@ -1644,7 +1646,7 @@ export const LevelingQuest: Quest = {
           .trySkill($skill`Shattering Punch`)
           .trySkill($skill`Gingerbread Mob Hit`)
           .trySkill($skill`Bowl Sideways`)
-          .default(useCinch),
+          .default(useCinch)
       ),
       choices: {
         1094: 5,


### PR DESCRIPTION
Lint removed a bundle of commas. I can re-PR without running lint.

Adjusted LOV-equip to be class generic. 

Updated barrel shrine to work for saucerors only (I don't own it, can't test it).

There's an opportunity to update the Outfit maximizer script from:

> modifier: `0.25 ${mainStatMaximizerStr}, 0.33 ML, -equip tinsel tights, -equip wad of used tape`,

to:

> modifier: ` ${primeStat}, 4 ML, 3 ${primeStat} exp, 1.33 exp, 30 ${primeStat} experience percent, 3 familiar exp, -equip tinsel tights, -equip wad of used tape`,

Which will improve leveling somewhat and ensure that LOV Epaulettes are automatically equipped when available; but I didn't include this in this PR.