### PR TITLE
Fix the familiar check on `melodramedary()`

### DIFF
--- a/src/tasks/runstart.ts
+++ b/src/tasks/runstart.ts
@@ -542,7 +542,7 @@ export const RunStartQuest: Quest = {
         let piccoloValue = 1; // +10 famwt, +120 famxp (potentially great for chest mimic)
 
         // If we aren't using the CBB nor melodramedary, we probably have enough fam turns
-        if (!cookbookbat() && !melodramedary()) quadTomValue -= 10;
+        if (!cookbookbat() && melodramedary() !== $familiar`Melodramedary`) quadTomValue -= 10;
 
         // If we can saber run with extinguisher, the hot res is probably not very useful
         if (have($item`Fourth of May Cosplay Saber`) && have($item`industrial fire extinguisher`))


### PR DESCRIPTION
The `melodramedary()` function returns a Familiar (`$familiar.none` is still considered a Familiar), so the check needs to be a more specific comparison.