### PR TITLE
Revise Apriling instrument preference regex

### DIFF
--- a/src/tasks/runstart.ts
+++ b/src/tasks/runstart.ts
@@ -574,11 +574,15 @@ export const RunStartQuest: Quest = {
             [$item`Apriling band piccolo`, piccoloValue],
           ]),
         ]
-          .filter(
-            ([it]) =>
-              !have(it) && // Remove option if we already have the item
-              !get(`instant_save${it.name.replace(/( \w)/, (_, g) => g.toUpperCase())}`, false), // or if we chose to not acquire it
-          )
+          .filter(([it]) => {
+            const preferenceName = `instant_save${it.name
+              .split(" ")
+              .map((word, index) =>
+                index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1),
+              )
+              .join("")}`;
+            return !have(it) && !get(preferenceName, false); // Remove option if we already have the item or if we chose to not acquire it
+          })
           .sort(([, a], [, b]) => b - a) // Sort the instruments in decreasing priority value (the higher the better)
           .slice(0, 2 - get("_aprilBandInstruments")) // We can acquire at most 2 instruments
           .forEach(([it]) => {


### PR DESCRIPTION
## Context

For the instrument saving preference filter 
```
!get(`instant_save${it.name.replace(/( \w)/, (_, g) => g.toUpperCase())}`, false)
```
the preference names I believe aren't quite right. This is making the script ignore preferences like `instant_saveAprilingBandStaff`:

```
--- Resources pertaining to aftercore farming profits ---
...
✓ instant_saveAprilingBandStaff - Do not acquire the Apriling Band Staff

...

> Executing Run Start/Get Apriling Band Instruments
> CCS: [default]\n ";"
Took choice 1526/7: Join the Drum Majors
choice.php?whichchoice=1526&option=7&pwd
You acquire an item: Apriling band staff
```

## Root Cause

`it.name.replace(/( \w)/, (_, g) => g.toUpperCase())`

This regex replaces the first space followed by a letter with the letter in uppercase, doesn't match the preferences properly

Example:

```
For it.name = "Apriling band quad tom"

Matched: "q" (space followed by 'q')
Replaced: Q
Result: "instant_saveApriling bandQuad tom"
For it.name = "Apriling band saxophone"

Matched: "s" (space followed by 's')
Replaced: S
Result: "instant_saveApriling bandSaxophone"

Preferences:
[
  "instant_saveApriling bandQuad tom",
  "instant_saveApriling bandSaxophone",
  "instant_saveApriling bandStaff",
  "instant_saveApriling bandPiccolo"
]
```

## Fix

More verbose, but I just split, capitalized, and rejoined.

```
For it.name = "Apriling band quad tom"

Split: ["Apriling", "band", "quad", "tom"]
Capitalized: ["Apriling", "Band", "Quad", "Tom"]
Joined: "AprilingBandQuadTom"
Result: "instant_saveAprilingBandQuadTom"
For it.name = "Apriling band saxophone"

Split: ["Apriling", "band", "saxophone"]
Capitalized: ["Apriling", "Band", "Saxophone"]
Joined: "AprilingBandSaxophone"
Result: "instant_saveAprilingBandSaxophone"

Fixed:
[
  "instant_saveAprilingBandQuadTom",
  "instant_saveAprilingBandSaxophone",
  "instant_saveAprilingBandStaff",
  "instant_saveAprilingBandPiccolo"
]
```