### PR TITLE
Refresh status after Sept-ember Mouthwash

### DIFF
--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -587,7 +587,11 @@ export const LevelingQuest: Quest = {
           visitUrl("place.php?whichplace=campaway&action=campaway_sky");
       },
       completed: () => !have($item`a ten-percent bonus`),
-      do: () => use($item`a ten-percent bonus`, 1),
+      do: () => {
+        use($item`a ten-percent bonus`, 1);
+
+        refreshStatus();
+      },
       limit: { tries: 1 },
     },
     {

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -587,9 +587,8 @@ export const LevelingQuest: Quest = {
           visitUrl("place.php?whichplace=campaway&action=campaway_sky");
       },
       completed: () => !have($item`a ten-percent bonus`),
-      do: () => {
-        use($item`a ten-percent bonus`, 1);
-
+      do: () => use($item`a ten-percent bonus`, 1),
+      post: (): void => {
         refreshStatus();
       },
       limit: { tries: 1 },
@@ -723,8 +722,6 @@ export const LevelingQuest: Quest = {
 
         cliExecute("maximize cold res");
         use($item`Mmm-brr! brand mouthwash`, 2);
-
-        refreshStatus();
       },
       limit: { tries: 1 },
       outfit: {
@@ -733,6 +730,7 @@ export const LevelingQuest: Quest = {
       },
       post: (): void => {
         if (have($effect`Scarysauce`)) cliExecute("shrug scarysauce");
+        refreshStatus();
       },
     },
     {

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -38,6 +38,7 @@ import {
   mySoulsauce,
   print,
   putCloset,
+  refreshStatus,
   restoreHp,
   retrieveItem,
   runChoice,
@@ -718,6 +719,8 @@ export const LevelingQuest: Quest = {
 
         cliExecute("maximize cold res");
         use($item`Mmm-brr! brand mouthwash`, 2);
+
+        refreshStatus();
       },
       limit: { tries: 1 },
       outfit: {


### PR DESCRIPTION
This is more of a KoLmafia issue, but it happens fairly often in my runs:

I'll be under level 5 when `Leveling/Use Ten-Percent Bonus` or `Leveling/Sept-ember Mouthwash` runs (depending on the day), raising me up a few levels. Then it'll try to run `Leveling/Eat Calzone` (which has a level 5 minimum requirement), but it aborts instead.

Checking my `status`, KoLmafia still thinks I'm under level 5.  So, I just run `instantsccs` again and it proceeds just fine, presumably because InstantSCCS does a `refresh` right at the start.

So, this PR just does a `refresh status` after these two stat jumps.
