### PR TITLE
Task Run Start/Peridot Novelty Tropical Skeleton did not complete within 2 attempts. Please check what went wrong.

### DIFF
--- a/src/tasks/runstart.ts
+++ b/src/tasks/runstart.ts
@@ -156,15 +156,6 @@ export const RunStartQuest: Quest = {
       limit: { tries: 1 },
     },
     {
-      name: "Skeleton Store",
-      completed: () => get("questM23Meatsmith") !== "unstarted",
-      do: (): void => {
-        visitUrl("shop.php?whichshop=meatsmith&action=talk");
-        runChoice(1);
-      },
-      limit: { tries: 1 },
-    },
-    {
       name: "Overgrown Lot",
       completed: () => get("questM24Doc") !== "unstarted",
       do: (): void => {
@@ -938,6 +929,19 @@ export const RunStartQuest: Quest = {
       limit: { tries: 1 },
     },
     {
+      name: "Skeleton Store",
+      completed: () => get("questM23Meatsmith") !== "unstarted",
+      do: (): void => {
+        visitUrl("shop.php?whichshop=meatsmith&action=talk");
+        runChoice(1);
+
+        // The initial free NC is untracked and is best done in the same task
+        // It also changes the location, which is good for Archaeologist's Spade
+        adv1($location`The Skeleton Store`);
+      },
+      limit: { tries: 1 },
+    },
+    {
       name: "Archaeologist's Spade Skeletons",
       ready: () => myLocation() === $location`The Skeleton Store`,
       completed: () =>
@@ -966,6 +970,7 @@ export const RunStartQuest: Quest = {
       completed: () =>
         mainStat === $stat`Moxie` || !have($item`Peridot of Peril`) || have($item`cherry`),
       do: $location`The Skeleton Store`,
+      choices: { 1060: 5 },
       combat: new CombatStrategy().macro(
         Macro.if_($monster`time cop`, Macro.default())
           .if_(
@@ -1068,6 +1073,7 @@ export const RunStartQuest: Quest = {
             completedSkeletonBanishes() ||
             !haveFreeSkeletonBanish())),
       do: $location`The Skeleton Store`,
+      choices: { 1060: 5 },
       combat: new CombatStrategy().macro(() =>
         Macro.if_(
           "!haseffect Everything Looks Yellow",


### PR DESCRIPTION
# Situation

*  [Peridot Novelty Tropical Skeleton](https://github.com/Pantocyclus/InstantSCCS/blob/b49699e26a21a1a6800fbc92086509bb96fc5fe8/src/tasks/runstart.ts#L994) runs and hits the initial free greetings NC, "Welcone to the Skeleton Store". Despite it costing us nothing, this does change our last location.
* [Archaeologist's Spade Skeletons](https://github.com/Pantocyclus/InstantSCCS/blob/b49699e26a21a1a6800fbc92086509bb96fc5fe8/src/tasks/runstart.ts#L941) then runs due to the changed location. We fail to drop a cherry for all 11 fights. It increments the turns in the zone by 1 with every failure.
* [Peridot Novelty Tropical Skeleton](https://github.com/Pantocyclus/InstantSCCS/blob/b49699e26a21a1a6800fbc92086509bb96fc5fe8/src/tasks/runstart.ts#L994) then runs again, which due to the turns being incremented, is now the modular % 4 == 3 in the zone, which will hit the scheduled NC [Temporarily Out of Skeletons](https://wiki.kingdomofloathing.com/Temporarily_Out_of_Skeletons#Just_leave). 
* Choice runs as per choiceAdventure1060.
* As the task `Peridot Novelty Tropical Skeleton` has now run twice, it will fail.
 
# Conclusion

1. The initial free NC is advantageous for the spade due to location switching.
2. The initial free NC cannot be tracked, the unstarted questline can, and the two are basically the same.
3. The location switching should be just before it becomes relevant
4. Peridot task still has two attempts, because it may hit the NC and tracking that cleanly is not simple at a glance.
5. The [Scheduled NC](https://wiki.kingdomofloathing.com/Temporarily_Out_of_Skeletons#Just_leave) is now handled and skipped.