### PR TITLE
Skeletons v2 - Allow tasks to say they were not attempted

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -309,6 +309,12 @@ export class Engine extends BaseEngine {
     if (task.combat !== undefined && myHp() < myMaxhp() * 0.9) useSkill($skill`Cannelloni Cocoon`);
   }
 
+  markAttempt(task: Task): void {
+    if (!(task.name in this.attempts)) this.attempts[task.name] = 0;
+    if (!task.attempted || task.attempted()) this.attempts[task.name]++;
+    else set("lastEncounter", "");
+  }
+
   initPropertiesManager(manager: PropertiesManager): void {
     super.initPropertiesManager(manager);
     const bannedAutoRestorers = [

--- a/src/engine/task.ts
+++ b/src/engine/task.ts
@@ -1,4 +1,6 @@
 import { Quest as BaseQuest, Task as BaseTask } from "grimoire-kolmafia";
 
 export type Quest = BaseQuest<Task>;
-export type Task = BaseTask;
+export type Task = BaseTask & {
+  attempted?: () => boolean;
+};

--- a/src/tasks/runstart.ts
+++ b/src/tasks/runstart.ts
@@ -966,6 +966,7 @@ export const RunStartQuest: Quest = {
       completed: () =>
         mainStat === $stat`Moxie` || !have($item`Peridot of Peril`) || have($item`cherry`),
       do: $location`The Skeleton Store`,
+      choices: { 1060: 5 },
       combat: new CombatStrategy().macro(
         Macro.if_($monster`time cop`, Macro.default())
           .if_(
@@ -991,6 +992,10 @@ export const RunStartQuest: Quest = {
           use($item`MayDay™ supply package`, 1);
         if (have($item`space blanket`)) autosell($item`space blanket`, 1);
       },
+      attempted: () =>
+        !["Skeletons In Store", "Temporarily Out of Skeletons", "time cop"].includes(
+          get("lastEncounter"),
+        ),
       limit: { tries: 2 },
     },
     {
@@ -1047,6 +1052,10 @@ export const RunStartQuest: Quest = {
           use($item`MayDay™ supply package`, 1);
         if (have($item`space blanket`)) autosell($item`space blanket`, 1);
       },
+      attempted: () =>
+        !["Skeletons In Store", "Temporarily Out of Skeletons", "time cop"].includes(
+          get("lastEncounter"),
+        ),
       limit: { tries: 2 },
     },
     {
@@ -1068,16 +1077,18 @@ export const RunStartQuest: Quest = {
             completedSkeletonBanishes() ||
             !haveFreeSkeletonBanish())),
       do: $location`The Skeleton Store`,
+      choices: { 1060: 5 },
       combat: new CombatStrategy().macro(() =>
-        Macro.if_(
-          "!haseffect Everything Looks Yellow",
-          Macro.if_(
-            $monster`novelty tropical skeleton`,
-            Macro.externalIf(useParkaSpit, Macro.trySkill($skill`Spit jurassic acid`))
-              .trySkill($skill`Blow the Yellow Candle!`)
-              .tryItem($item`yellow rocket`),
-          ),
-        )
+        Macro.if_($monster`time cop`, Macro.default())
+          .if_(
+            "!haseffect Everything Looks Yellow",
+            Macro.if_(
+              $monster`novelty tropical skeleton`,
+              Macro.externalIf(useParkaSpit, Macro.trySkill($skill`Spit jurassic acid`))
+                .trySkill($skill`Blow the Yellow Candle!`)
+                .tryItem($item`yellow rocket`),
+            ),
+          )
           .externalIf(
             !Array.from(getBanishedMonsters().keys()).includes($skill`Bowl a Curveball`),
             Macro.trySkill($skill`Bowl a Curveball`),
@@ -1114,6 +1125,10 @@ export const RunStartQuest: Quest = {
           use($item`MayDay™ supply package`, 1);
         if (have($item`space blanket`)) autosell($item`space blanket`, 1);
       },
+      attempted: () =>
+        !["Skeletons In Store", "Temporarily Out of Skeletons", "time cop"].includes(
+          get("lastEncounter"),
+        ),
       limit: { tries: 4 },
     },
     {


### PR DESCRIPTION
So this PR is a different approach as the base issue as I see it, is really that the engine logs it as an attempt, when it wasn't a proper attempt.

The first commit introduces a new parameter that tasks can implement, a function that lets them declare if the task was indeed attempted or not.
This could potentially be expanded for other tasks, that have encounters that were distractions and didn't actually attempt the real task.

Skeletons now have a choice set to skip the scheduled NC, and will not mark the task as attempted if it hit either NC, or a time cop.

Haven't tested it, will do tomorrow though don't expect any issues.

If this approach doesn't seem good, lmk and I'll do a third PR where it simply adds the choices without looking at the initial NC :+1: 