### PR TITLE
Add save cosplay saber force uses

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -320,6 +320,12 @@ export const otherResources: Resource[] = [
     [],
     get("instant_saveHeartstoneKill", false) ? 5 : 0,
   ),
+  new Resource(
+    "instant_saveSaberForceUses",
+    (n) => `Save ${n}/5 Cosplay Saber Force Uses`,
+    [],
+    get("instant_saveSaberForceUses", false) ? 5 : 0,
+  ),
 ];
 
 const allResources = [

--- a/src/tasks/boozedrop.ts
+++ b/src/tasks/boozedrop.ts
@@ -251,7 +251,10 @@ export const BoozeDropQuest: Quest = {
         Macro.trySkill($skill`Bowl Straight Up`)
           .trySkill($skill`Become a Bat`)
           .trySkill($skill`Fire Extinguisher: Polar Vortex`)
-          .trySkill($skill`Use the Force`)
+          .externalIf(
+            get("_saberForceUses") < 5 - get("instant_saveSaberForceUses", 0),
+            Macro.trySkill($skill`Use the Force`),
+          )
           .default(),
       ),
       limit: { tries: 5 },

--- a/src/tasks/boozedrop.ts
+++ b/src/tasks/boozedrop.ts
@@ -238,7 +238,10 @@ export const BoozeDropQuest: Quest = {
             ? $item`Daylight Shavings Helmet`
             : undefined,
         back: $item`vampyric cloake`,
-        weapon: $item`Fourth of May Cosplay Saber`,
+        weapon:
+          get("_saberForceUses") < 5 - get("instant_saveSaberForceUses", 0)
+            ? $item`Fourth of May Cosplay Saber`
+            : undefined,
         offhand: have($skill`Double-Fisted Skull Smashing`)
           ? $item`industrial fire extinguisher`
           : undefined,

--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -91,7 +91,7 @@ export const FamiliarWeightQuest: Quest = {
         acquiredOrExcluded($effect`Meteor Showered`) ||
         !have($item`Fourth of May Cosplay Saber`) ||
         !have($skill`Meteor Lore`) ||
-        get("_saberForceUses") >= 5,
+        get("_saberForceUses") >= 5 - get("instant_saveSaberForceUses", 0),
       do: $location`The Dire Warren`,
       combat: new CombatStrategy().macro(
         Macro.trySkill($skill`Meteor Shower`)

--- a/src/tasks/hotres.ts
+++ b/src/tasks/hotres.ts
@@ -94,7 +94,10 @@ export const HotResQuest: Quest = {
       outfit: () => ({
         back: $item`vampyric cloake`,
         shirt: $item`Jurassic Parka`,
-        weapon: $item`Fourth of May Cosplay Saber`,
+        weapon:
+          get("_saberForceUses") < 5 - get("instant_saveSaberForceUses", 0)
+            ? $item`Fourth of May Cosplay Saber`
+            : undefined,
         offhand: have($skill`Double-Fisted Skull Smashing`)
           ? $item`industrial fire extinguisher`
           : have($effect`Everything Looks Yellow`)

--- a/src/tasks/hotres.ts
+++ b/src/tasks/hotres.ts
@@ -108,7 +108,10 @@ export const HotResQuest: Quest = {
       combat: new CombatStrategy().macro(
         Macro.trySkill($skill`Become a Cloud of Mist`)
           .trySkill($skill`Fire Extinguisher: Foam Yourself`)
-          .trySkill($skill`Use the Force`)
+          .externalIf(
+            get("_saberForceUses") < 5 - get("instant_saveSaberForceUses", 0),
+            Macro.trySkill($skill`Use the Force`),
+          )
           .trySkill($skill`Shocking Lick`)
           .if_(
             "!haseffect Everything Looks Yellow",
@@ -130,7 +133,7 @@ export const HotResQuest: Quest = {
       completed: () =>
         acquiredOrExcluded($effect`Fireproof Foam Suit`) ||
         !have($item`Fourth of May Cosplay Saber`) ||
-        get("_saberForceUses") >= 5 ||
+        get("_saberForceUses") >= 5 - get("instant_saveSaberForceUses", 0) ||
         !have($item`industrial fire extinguisher`) ||
         !have($skill`Double-Fisted Skull Smashing`),
       do: $location`The Dire Warren`,

--- a/src/tasks/spelldamage.ts
+++ b/src/tasks/spelldamage.ts
@@ -207,7 +207,7 @@ export const SpellDamageQuest: Quest = {
         acquiredOrExcluded($effect`Meteor Showered`) ||
         !have($item`Fourth of May Cosplay Saber`) ||
         !have($skill`Meteor Lore`) ||
-        get("_saberForceUses") >= 5,
+        get("_saberForceUses") >= 5 - get("instant_saveSaberForceUses", 0),
       do: $location`The Dire Warren`,
       combat: new CombatStrategy().macro(
         Macro.trySkill($skill`Meteor Shower`)

--- a/src/tasks/weapondamage.ts
+++ b/src/tasks/weapondamage.ts
@@ -185,7 +185,7 @@ export const WeaponDamageQuest: Quest = {
         acquiredOrExcluded($effect`Meteor Showered`) ||
         !have($item`Fourth of May Cosplay Saber`) ||
         !have($skill`Meteor Lore`) ||
-        get("_saberForceUses") >= 5,
+        get("_saberForceUses") >= 5 - get("instant_saveSaberForceUses", 0),
       do: attemptKFH ? powerlevelingLocation() : $location`The Dire Warren`,
       combat: new CombatStrategy().macro(
         Macro.trySkill($skill`Meteor Shower`)


### PR DESCRIPTION
Adds ability to save uses of cosplay saber.
In my usecase, I mostly just need to disable the cosplay saber when using familiars that deal damage.

This is sub-optimal, in that if you're just limiting it to a value between 0 and 5, it may burn the uses on the tasks that don't need it. Fixing that however, would be a proposal of a knapsack script.