### PR TITLE
Fix logic for applying task limits

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -187,7 +187,7 @@ export class Engine extends BaseEngine {
     const originalTries = task.limit?.tries;
     if (task.limit?.tries) task.limit.tries = undefined;
     super.execute(task);
-    if (task.limit?.tries) task.limit.tries = originalTries;
+    if (task.limit && originalTries) task.limit.tries = originalTries;
     if (have($effect`Beaten Up`)) {
       if (["Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl"].includes(get("lastEncounter")))
         uneffect($effect`Beaten Up`);


### PR DESCRIPTION
[A recent change](https://github.com/Pantocyclus/InstantSCCS/commit/1d3311884d35b0455dc45dc9e3ad428341739ec4) temporarily set limits to undefined during task execution so InstantSCCS could handle some situations itself, then resets the task limits to the original values afterward. However, the code introduced there has a bug:
```
    if (task.limit?.tries) task.limit.tries = undefined;
    super.execute(task);
    if (task.limit?.tries) task.limit.tries = originalTries;
```

The if clause on the 3rd line will always be false, as the 1st line sets task.limit.tries to undefined (if it's defined in the first place). That means the task limits never get set back to what they originally were afterward.

Before this PR, I was seeing infinite loops instead of limits getting enforced correctly, and afterward limits are applying correctly again.